### PR TITLE
remove customer_serial_number and manufacturer_serial_number

### DIFF
--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -5,12 +5,11 @@ from dataclasses import dataclass
 
 @dataclass
 class DutIdentifier:
-    customer_serial_number: str
-    manufacturer_serial_number: Optional[str] = None
+    halter_serial_number: str
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
     additional: Optional[dict] = None
 
     @property
     def test_id(self) -> str:
-        return self.manufacturer_serial_number or self.customer_serial_number
+        return self.halter_serial_number


### PR DESCRIPTION
add halter_serial_number
dut_id will be the primary unique identifier - this may be the contract manufacturer's number or the halter serial number depending on the situation.