### PR TITLE
Prevent UI lockup caused by PubSub race condition

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -14,6 +14,7 @@
 """The main OpenHTF entry point."""
 
 import signal
+import sys
 import typing
 
 from openhtf.core import phase_executor
@@ -147,3 +148,7 @@ __version__ = get_version()
 
 # Register signal handler to stop all tests on SIGINT.
 Test.DEFAULT_SIGINT_HANDLER = signal.signal(signal.SIGINT, Test.handle_sig_int)
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -5,12 +5,11 @@ from dataclasses import dataclass
 
 @dataclass
 class DutIdentifier:
-    customer_serial_number: str
-    manufacturer_serial_number: Optional[str] = None
+    halter_serial_number: str
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
     additional: Optional[dict] = None
 
     @property
     def test_id(self) -> str:
-        return self.manufacturer_serial_number or self.customer_serial_number
+        return self.halter_serial_number

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class DutIdentifier:
+    customer_serial_number: str
+    manufacturer_serial_number: Optional[str] = None
+    mac_address: Optional[str] = None
+    part_number: Optional[str] = None
+    additional: Optional[dict] = None
+
+    @property
+    def test_id(self) -> str:
+        return self.manufacturer_serial_number or self.customer_serial_number

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 @dataclass
 class DutIdentifier:
-    halter_serial_number: str
+    halter_serial_number: Optional [str] = None
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
     additional: Optional[dict] = None

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 
 @dataclass
 class DutIdentifier:
-    serial_number_halter: Optional[str] = None
-    serial_number_component: Optional[str] = None
+    halter_serial_number: Optional[str] = None
+    manufacturer_serial_number: Optional[str] = None
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
     additional: dict = field(default_factory=dict)
 
     @property
     def test_id(self) -> str:
-        return self.serial_number_halter
+        return self.halter_serial_number

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -4,11 +4,12 @@ from dataclasses import dataclass, field
 
 @dataclass
 class DutIdentifier:
-    halter_serial_number: Optional[str] = None
+    serial_number_halter: Optional[str] = None
+    serial_number_component: Optional[str] = None
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
     additional: dict = field(default_factory=dict)
 
     @property
     def test_id(self) -> str:
-        return self.halter_serial_number
+        return self.serial_number_halter

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -1,14 +1,13 @@
-from dataclasses import dataclass
 from typing import Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class DutIdentifier:
-    halter_serial_number: Optional [str] = None
+    halter_serial_number: Optional[str] = None
     mac_address: Optional[str] = None
     part_number: Optional[str] = None
-    additional: Optional[dict] = None
+    additional: dict = field(default_factory=dict)
 
     @property
     def test_id(self) -> str:

--- a/openhtf/core/dut_id.py
+++ b/openhtf/core/dut_id.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class DutIdentifier:
+    customer_serial_number: str
+    manufacturer_serial_number: Optional[str] = None
+    mac_address: Optional[str] = None
+    part_number: Optional[str] = None
+
+    @property
+    def test_id(self) -> str:
+        return self.manufacturer_serial_number or self.customer_serial_number

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -170,7 +170,6 @@ class TestRecord(object):
 
   dut_id = attr.ib(type=Optional[Text])
   dut_extended_id = attr.ib(type=Optional[DutIdentifier])
-  test_station = attr.ib(type=Text)
   station_id = attr.ib(type=Text)
   start_time_millis = attr.ib(type=int, default=0)
   end_time_millis = attr.ib(type=Optional[int], default=None)
@@ -255,7 +254,6 @@ class TestRecord(object):
     ret = {
         'dut_id': data.convert_to_base_types(self.dut_id),
         'dut_extended_id': data.convert_to_base_types (self.dut_extended_id),
-        'test_station': data.convert_to_base_types (self.test_station),
         'start_time_millis': self.start_time_millis,
         'end_time_millis': self.end_time_millis,
         'outcome': data.convert_to_base_types(self.outcome),

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -167,6 +167,9 @@ class TestRecord(object):
   """The record of a single run of a test."""
 
   dut_id = attr.ib(type=Optional[Text])
+  dut_mac = attr.ib(type=Optional[Text])
+  dut_halter_sn = attr.ib(type=Optional[Text])
+  dut_part_number = attr.ib(type=Optional[Text])
   station_id = attr.ib(type=Text)
   start_time_millis = attr.ib(type=int, default=0)
   end_time_millis = attr.ib(type=Optional[int], default=None)

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Text, TYPE_CHECKING, Union
 import attr
 
 from openhtf import util
+from openhtf.core.dut_id import DutIdentifier
 from openhtf.util import configuration
 from openhtf.util import data
 from openhtf.util import logs
@@ -167,9 +168,7 @@ class TestRecord(object):
   """The record of a single run of a test."""
 
   dut_id = attr.ib(type=Optional[Text])
-  dut_mac = attr.ib(type=Optional[Text])
-  dut_halter_sn = attr.ib(type=Optional[Text])
-  dut_part_number = attr.ib(type=Optional[Text])
+  dut_extended_id = attr.ib(type=Optional[DutIdentifier])
   station_id = attr.ib(type=Text)
   start_time_millis = attr.ib(type=int, default=0)
   end_time_millis = attr.ib(type=Optional[int], default=None)

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -16,6 +16,7 @@
 import enum
 import hashlib
 import inspect
+import json
 import logging
 import os
 import tempfile
@@ -253,6 +254,7 @@ class TestRecord(object):
     metadata['config'] = self._cached_config_from_metadata
     ret = {
         'dut_id': data.convert_to_base_types(self.dut_id),
+        'dut_extended_id': data.convert_to_base_types (self.dut_extended_id),
         'start_time_millis': self.start_time_millis,
         'end_time_millis': self.end_time_millis,
         'outcome': data.convert_to_base_types(self.outcome),

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -170,6 +170,7 @@ class TestRecord(object):
 
   dut_id = attr.ib(type=Optional[Text])
   dut_extended_id = attr.ib(type=Optional[DutIdentifier])
+  test_station = attr.ib(type=Text)
   station_id = attr.ib(type=Text)
   start_time_millis = attr.ib(type=int, default=0)
   end_time_millis = attr.ib(type=Optional[int], default=None)
@@ -254,6 +255,7 @@ class TestRecord(object):
     ret = {
         'dut_id': data.convert_to_base_types(self.dut_id),
         'dut_extended_id': data.convert_to_base_types (self.dut_extended_id),
+        'test_station': data.convert_to_base_types (self.test_station),
         'start_time_millis': self.start_time_millis,
         'end_time_millis': self.end_time_millis,
         'outcome': data.convert_to_base_types(self.outcome),

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -174,6 +174,9 @@ class TestState(util.SubscribableStateMixin):
 
     self.test_record = test_record.TestRecord(
         dut_id=None,
+        dut_mac=None,
+        dut_halter_sn=None,
+        dut_part_number=None,
         station_id=CONF.station_id,
         code_info=test_desc.code_info,
         start_time_millis=0,

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -175,6 +175,7 @@ class TestState(util.SubscribableStateMixin):
     self.test_record = test_record.TestRecord(
         dut_id=None,
         dut_extended_id=None,
+        test_station=None,
         station_id=CONF.station_id,
         code_info=test_desc.code_info,
         start_time_millis=0,

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -174,9 +174,7 @@ class TestState(util.SubscribableStateMixin):
 
     self.test_record = test_record.TestRecord(
         dut_id=None,
-        dut_mac=None,
-        dut_halter_sn=None,
-        dut_part_number=None,
+        dut_extended_id=None,
         station_id=CONF.station_id,
         code_info=test_desc.code_info,
         start_time_millis=0,

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -175,7 +175,6 @@ class TestState(util.SubscribableStateMixin):
     self.test_record = test_record.TestRecord(
         dut_id=None,
         dut_extended_id=None,
-        test_station=None,
         station_id=CONF.station_id,
         code_info=test_desc.code_info,
         start_time_millis=0,


### PR DESCRIPTION
When running tests multiple times, occasionally we see an error "HTTP request for phase descriptors failed." in the web UI when a test completes, preventing us from starting the test again.

From some sleuthing in the web ui console, I noticed that the PubSub websocket publishes (what it believes to be) the test UID of the currently running test. The web ui then requests `tests/<test_uid>/phases`, which should return the phase info for that test. However, when we see this error, I noticed that it's sending the request of the previous test. The python only stores the information of the currently running test, and so the request for the previous test info fails.

The issue here (I believe) is that when a test is finishing and a new test is started, the event for the previous test finishing arrives after the notification for the new test starting. This means we store the UID of the previous test in `StationPubSub`, and incorrectly report that test UID to the webui, causing it to request the phase info for the old test.

My hacky workaround for this is to only allow changing the UID for the test when we've never seen the test UID before. If we see an update for an old test, we refuse to update the uid.