### PR TITLE
Makes phases clickable to only expand one

### DIFF
--- a/openhtf/output/web_gui/src/app/stations/station/phase.component.html
+++ b/openhtf/output/web_gui/src/app/stations/station/phase.component.html
@@ -15,18 +15,20 @@
 -->
 
 <div class="htf-layout-header" [class.header-with-measurements]="showMeasurements">
-  <span class="u-clamp-text">
-    <span class="phase-name">{{ phase.name }}</span>
-    <span *ngIf="phase.status !== PhaseStatus.waiting">
-      &nbsp;{{ phase | elapsedTime:'(%s)' }}
+  <div (click)="togglePhase()" class="header-content" [class.header-content-clickable]="hasMeasurements">
+    <span class="u-clamp-text">
+      <span class="phase-name">{{ phase.name }}</span>
+      <span *ngIf="phase.status !== PhaseStatus.waiting">
+        &nbsp;{{ phase | elapsedTime:'(%s)' }}
+      </span>
     </span>
-  </span>
 
-  <div class="u-flex-grow"></div>
-  <div
-    class="htf-status-indicator"
-    [ngClass]="phase.status | statusToClass">
-    {{ phase.status | statusToText }}
+    <div class="u-flex-grow"></div>
+    <div
+      class="htf-status-indicator"
+      [ngClass]="phase.status | statusToClass">
+      {{ phase.status | statusToText }}
+    </div>
   </div>
 </div>
 

--- a/openhtf/output/web_gui/src/app/stations/station/phase.component.scss
+++ b/openhtf/output/web_gui/src/app/stations/station/phase.component.scss
@@ -16,6 +16,18 @@
 
 @import 'vars';
 
+.header-content {
+  background: none;
+  border: none;
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+.header-content-clickable {
+  cursor: pointer;
+}
+
 .header-with-measurements {
   border-bottom: 1px solid $border-light-grey;
 }

--- a/openhtf/output/web_gui/src/app/stations/station/phase.component.ts
+++ b/openhtf/output/web_gui/src/app/stations/station/phase.component.ts
@@ -38,4 +38,12 @@ export class PhaseComponent {
   get showMeasurements() {
     return this.expand && this.phase.measurements.length > 0;
   }
+
+  get hasMeasurements() {
+    return this.phase.measurements.length > 0;
+  }
+
+  togglePhase() {
+    this.expand = !this.expand;
+  }
 }


### PR DESCRIPTION
Cursor goes to the pointy finger when phase has measurements, clicking it will expand only that one phase
![image](https://github.com/user-attachments/assets/4cc26b32-61e3-4dcd-a6dc-429680c5bdcb)
