### PR TITLE
add new validator

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -441,6 +441,7 @@ def matches_regex(regex):
   return RegexMatcher(regex, re.compile(regex))
 
 class MultiRegexMatcher(ValidatorBase):
+class MultiRegexMatcher(ValidatorBase):
     def __init__(self, regex_list: list[str], compiled_list: list[re.Pattern]) -> None:
         self.regex_list = regex_list
         self._compiled_list = compiled_list
@@ -466,10 +467,23 @@ class MultiRegexMatcher(ValidatorBase):
         return not self == other
 
 @register
-def matches_any_regex(regex_list: list[str]):
-    compiled_list = [re.compile(regex) for regex in regex_list]
-    return MultiRegexMatcher(regex_list, compiled_list)
+def matches_any_regex(*regex_lists: list[list[str]]):
+    """
+    Creates a validator that checks if a value matches ANY of the provided regex patterns.
 
+    Accepts one or more lists of regex strings.
+    Example: matches_any_regex(['a.*'], ['b.*', 'c.*'])
+    """
+    # 1. Amalgamate all lists into a single flat list of regex strings
+    flat_regex_list = []
+    for regex_list in regex_lists:
+        flat_regex_list.extend(regex_list)
+    
+    # 2. Compile the flat list of regex strings
+    compiled_list = [re.compile(regex) for regex in flat_regex_list]
+    
+    # 3. Pass both the original flat list and the compiled list to the matcher
+    return MultiRegexMatcher(flat_regex_list, compiled_list)
 
 class WithinPercent(RangeValidatorBase):
   """Validates that a number is within percent of a value."""

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -440,6 +440,36 @@ class RegexMatcher(ValidatorBase):
 def matches_regex(regex):
   return RegexMatcher(regex, re.compile(regex))
 
+class MultiRegexMatcher(ValidatorBase):
+    def __init__(self, regex_list: list[str], compiled_list: list[re.Pattern]) -> None:
+        self.regex_list = regex_list
+        self._compiled_list = compiled_list
+
+    def __call__(self, value: str) -> bool:
+        str_value = str(value)
+        for compiled_pattern in self._compiled_list:
+            if compiled_pattern.match(str_value) is not None:
+                return True
+        return False
+
+    def __deepcopy__(self, dummy_memo):
+        return type(self)(self.regex_list[:], self._compiled_list[:])
+
+    def __str__(self):
+        patterns_str = " | ".join(self.regex_list)
+        return "'x' matches any of: /%s/" % patterns_str
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.regex_list == other.regex_list
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+@register
+def matches_any_regex(regex_list: list[str]):
+    compiled_list = [re.compile(regex) for regex in regex_list]
+    return MultiRegexMatcher(regex_list, compiled_list)
+
 
 class WithinPercent(RangeValidatorBase):
   """Validates that a number is within percent of a value."""

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -440,7 +440,7 @@ class RegexMatcher(ValidatorBase):
 def matches_regex(regex):
   return RegexMatcher(regex, re.compile(regex))
 
-class MultiRegexMatcher(ValidatorBase):
+
 class MultiRegexMatcher(ValidatorBase):
     def __init__(self, regex_list: list[str], compiled_list: list[re.Pattern]) -> None:
         self.regex_list = regex_list

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -466,19 +466,14 @@ class MultiRegexMatcher(ValidatorBase):
         return not self == other
 
 @register
-def matches_any_regex(*regex_lists: tuple[list[str]]):
-    """
-    Creates a validator that checks if a value matches ANY of the provided regex patterns.
-    """
-
+def matches_any_regex(*regex_collections: list[str]):
     flat_regex_list = []
-    for regex_list in regex_lists:
-        if not isinstance(regex_list, list) or not regex_list:
+    for collection in regex_collections:
+        if not isinstance(collection, list) or not collection:
             raise ValueError("Each argument must be a list of regex patterns.")
-        flat_regex_list.extend(regex_list)
-    
+        flat_regex_list.extend(collection)
+
     compiled_list = [re.compile(regex) for regex in flat_regex_list]
-    
     return MultiRegexMatcher(flat_regex_list, compiled_list)
 
 class WithinPercent(RangeValidatorBase):

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -446,10 +446,9 @@ class MultiRegexMatcher(ValidatorBase):
         self.regex_list = regex_list
         self._compiled_list = compiled_list
 
-    def __call__(self, value: str) -> bool:
-        str_value = str(value)
+    def __call__(self, candidate_str: str) -> bool:
         for compiled_pattern in self._compiled_list:
-            if compiled_pattern.match(str_value) is not None:
+            if compiled_pattern.match(candidate_str):
                 return True
         return False
 
@@ -467,22 +466,19 @@ class MultiRegexMatcher(ValidatorBase):
         return not self == other
 
 @register
-def matches_any_regex(*regex_lists: list[list[str]]):
+def matches_any_regex(*regex_lists: tuple[list[str]]):
     """
     Creates a validator that checks if a value matches ANY of the provided regex patterns.
-
-    Accepts one or more lists of regex strings.
-    Example: matches_any_regex(['a.*'], ['b.*', 'c.*'])
     """
-    # 1. Amalgamate all lists into a single flat list of regex strings
+
     flat_regex_list = []
     for regex_list in regex_lists:
+        if not isinstance(regex_list, list) or not regex_list:
+            raise ValueError("Each argument must be a list of regex patterns.")
         flat_regex_list.extend(regex_list)
     
-    # 2. Compile the flat list of regex strings
     compiled_list = [re.compile(regex) for regex in flat_regex_list]
     
-    # 3. Pass both the original flat list and the compiled list to the matcher
     return MultiRegexMatcher(flat_regex_list, compiled_list)
 
 class WithinPercent(RangeValidatorBase):

--- a/test/util/validators_test.py
+++ b/test/util/validators_test.py
@@ -78,6 +78,42 @@ class TestInRange(unittest.TestCase):
     self.assertEqual(test_validator.maximum, 0x12)
 
 
+class TestSingleRegex(unittest.TestCase):
+  def test_single_regex(self):
+    pattern = r'^[A-Z]{3}\d{3}$'
+    validator = validators.matches_regex(pattern)
+    self.assertTrue(validator('ABC123'))
+    self.assertFalse(validator('abc123'))
+    self.assertFalse(validator('AB1234'))
+    self.assertFalse(validator('ABCD12'))
+
+
+class TestMultipleRegex(unittest.TestCase):
+  patterns_1 = [r'^[A-Z]{1}\d{1}$', r'^[A-Z]{2}\d{2}$', r'^[A-Z]{3}\d{3}$']
+  patterns_2 = [r'^\d{1}[A-Z]{1}$']
+  def test_multiple_regex_lists(self):
+
+    validator_1 = validators.matches_any_regex(TestMultipleRegex.patterns_1, TestMultipleRegex.patterns_2)
+    self.assertTrue(validator_1('ABC123'))
+    self.assertTrue(validator_1('A1'))
+    self.assertTrue(validator_1('1A'))
+    self.assertFalse(validator_1('123-ABCD'))
+  
+  def test_single_regex_list(self):
+    validator_2 = validators.matches_any_regex(TestMultipleRegex.patterns_2)
+    self.assertTrue(validator_2('1A'))
+    self.assertFalse(validator_2('A1'))
+
+  def test_invalid_arguments(self):
+    with self.assertRaisesRegex(ValueError, "Each argument must be a list of regex patterns."):
+      validators.matches_any_regex(r'^[A-Z]{3}\d{3}$')
+
+    with self.assertRaisesRegex(ValueError, "Each argument must be a list of regex patterns."):
+      validators.matches_any_regex([])
+
+    with self.assertRaisesRegex(ValueError, "Each argument must be a list of regex patterns."):
+      validators.matches_any_regex(r'd{3}', r'd{4}')
+
 class TestAllInRange(unittest.TestCase):
 
   def setUp(self):
@@ -395,3 +431,7 @@ class ConsistentEndDimensionPivotTest(htf_test.TestCase):
 
     phase_record = yield phase
     self.assertMeasurementFail(phase_record, 'pivot')
+
+if __name__ == '__main__':
+  from unittest import main
+  main()

--- a/test/util/validators_test.py
+++ b/test/util/validators_test.py
@@ -431,7 +431,3 @@ class ConsistentEndDimensionPivotTest(htf_test.TestCase):
 
     phase_record = yield phase
     self.assertMeasurementFail(phase_record, 'pivot')
-
-if __name__ == '__main__':
-  from unittest import main
-  main()


### PR DESCRIPTION
New method, similar to the `matches_regex` validator, but takes in a list(s) of patterns. Validation passes if at least one pattern is matched. 
Usage can be like:

```
@htf.measures(htf.Measurement('P5_MAIN_SMT_ID').matches_any_regex(MainBoardStandardRegex.all_patterns, MainBoardOmniRegex.all_patterns))
def P5_MAIN_SMT_ID(test: htf.TestApi):
```
or

```
@htf.measures(htf.Measurement('P5_BATTERY_SN').matches_any_regex(BatteryRegex.all_patterns))
def P5_BATTERY_SN(test: htf.TestApi, prompts: UserInput):
```


This is to accomodate validating the part numbers for entity binding. There are often multiple acceptable formats per part. There is no overarching structure (apart from the datecode). It's easier to have classes for each part number which keep track of the acceptable regex patterns. https://github.com/halter-corp/hardware-test-framework/pull/960

We pass this object (a list of the patterns) into the validator `matches_any_regex`.

Unfortunately, it displays this horrendous string (amalgamation of the acceptable patterns) as a validator:
<img width="698" height="760" alt="image" src="https://github.com/user-attachments/assets/b6886de9-b057-4e57-89d7-19d312a414a2" />
