### PR TITLE
Feat/phase descriptor setter

### DIFF
--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -274,6 +274,10 @@ class PhaseDescriptor(phase_nodes.PhaseNode):
     if self.options.phase_name_case == PhaseNameCase.CAMEL:
       name = inflection.camelize(name)
     return name
+  
+  @name.setter
+  def name(self, value):
+    self.options.name = value
 
   @property
   def doc(self) -> Optional[Text]:

--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -274,7 +274,7 @@ class PhaseDescriptor(phase_nodes.PhaseNode):
     if self.options.phase_name_case == PhaseNameCase.CAMEL:
       name = inflection.camelize(name)
     return name
-  
+
   @name.setter
   def name(self, value):
     self.options.name = value


### PR DESCRIPTION
set name of dynamically created `PhaseDescriptors`. Useful for when you're creating a phase descriptor like so:
```
def make_custom_test(params: Params) -> htf.PhaseDescriptor:
    @htf.measures(htf.Measurement(f'MEASUREMENT-{params.param}'))
    @htf.plug(plug=somePlug)
    def phase(test: htf.TestApi, plug: somePlug):
        plug.do_something
        test.measurements[f'MEASUREMENT-{params.param}']
    phase.name = f'TESTING-{params.some_param}'
    return phase

```
`PhaseDescriptors` don't have a `__name__` attribute like normal functions, and the `name` attribute only had a getter.
