### PR TITLE
Fix Atomic output publishing truncated reports when serialization fails mid-stream

### DIFF
--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -21,6 +21,7 @@ examples.
 
 from collections.abc import Iterable
 import contextlib
+import os
 import pickle
 import shutil
 import tempfile
@@ -36,11 +37,20 @@ SerializedTestRecord = Union[Text, bytes, Iterator[Union[Text, bytes]]]
 
 # TODO(wallacbe): Switch to util
 class Atomic(object):
-  """Class that does atomic write in a contextual manner."""
+  """Class that does atomic write in a contextual manner.
+
+  The temporary file is created in the destination's directory so that
+  publishing is a true same-filesystem rename: readers can never observe a
+  partially written or partially copied file. Contents are fsynced before the
+  rename so a power loss cannot leave an empty or truncated file behind. On
+  serialization failure, discard() removes the temporary file instead of
+  publishing partial output.
+  """
 
   def __init__(self, filename: Text):
     self.filename = filename
-    self.temp = tempfile.NamedTemporaryFile(delete=False)
+    self.temp = tempfile.NamedTemporaryFile(
+        dir=os.path.dirname(filename) or None, delete=False)
 
   def write(self, write_data: Union[Text, bytes]) -> int:
     if isinstance(write_data, str):
@@ -48,8 +58,14 @@ class Atomic(object):
     return self.temp.write(write_data)
 
   def close(self) -> None:
+    self.temp.flush()
+    os.fsync(self.temp.fileno())
     self.temp.close()
     shutil.move(self.temp.name, self.filename)
+
+  def discard(self) -> None:
+    self.temp.close()
+    os.unlink(self.temp.name)
 
 
 class CloseAttachments(object):
@@ -120,7 +136,10 @@ class OutputToFile(object):
       output_file = self.open_file(filename)
       try:
         yield output_file
-      finally:
+      except BaseException:
+        output_file.discard()
+        raise
+      else:
         output_file.close()
     elif self.output_file:
       yield self.output_file

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -20,6 +20,8 @@ actually care for.
 
 import io
 import json
+import os
+import tempfile
 
 import openhtf as htf
 from openhtf import util
@@ -98,6 +100,43 @@ class TestOutput(test.TestCase):
         break
     else:
       raise AssertionError('No attachment named %s' % attachment_name)
+
+
+class TestAtomicOutput(test.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    super(TestAtomicOutput, cls).setUpClass()
+    cls._test = htf.Test(all_the_things.attachments)
+    cls._test.make_uid = lambda: 'UNITTEST:MOCK:UID'
+
+  @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
+  def test_json_published_atomically(self, user_mock):
+    user_mock.prompt.return_value = 'SomeWidget'
+    record = yield self._test
+    with tempfile.TemporaryDirectory() as tmpdir:
+      pattern = os.path.join(tmpdir, '{dut_id}.json')
+      json_factory.OutputToJSON(pattern, indent=2)(record)
+      published = os.listdir(tmpdir)
+      self.assertEqual(['%s.json' % record.dut_id], published)
+      with open(os.path.join(tmpdir, published[0])) as report:
+        json.load(report)
+
+  @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
+  def test_serialization_failure_publishes_nothing(self, user_mock):
+    user_mock.prompt.return_value = 'SomeWidget'
+    record = yield self._test
+    attachment = record.phases[-1].attachments['test_attachment']
+    original_filename = attachment._filename
+    attachment._filename = original_filename + '-missing'
+    try:
+      with tempfile.TemporaryDirectory() as tmpdir:
+        pattern = os.path.join(tmpdir, '{dut_id}.json')
+        with self.assertRaises(FileNotFoundError):
+          json_factory.OutputToJSON(pattern, indent=2)(record)
+        self.assertEqual([], os.listdir(tmpdir))
+    finally:
+      attachment._filename = original_filename
 
 
 class TestMfgEventOutput(test.TestCase):


### PR DESCRIPTION
Station report JSONs sometimes arrive truncated (typically the large base64-inlined WAV reports) and get quarantined as corrupt by the shipper. Root cause: `Atomic` publishes its temp file in a `finally`, so any mid-stream failure (lazy attachment read, ENOSPC) still moves partial output into the reports directory under a valid report name — and the test still reports PASS. The temp file also lived in /tmp (cross-filesystem move = non-atomic copy, racing the shipper's 5s poll) and was never fsynced (power yank can leave an empty file after the rename).

- Discard the temp file on failure instead of publishing it
- Create the temp file next to the destination so publishing is a true atomic rename
- fsync before renaming

`close()` keeps its name and semantics, so hardware-test-framework's `AtomicWithPermissions` subclass is unaffected. Regression tests included; full suite passes (511 passed, 2 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)